### PR TITLE
carousel image size fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,25 +45,25 @@
         <div class="container" name="slides">
             <div class="row">
                 <h3>Carousel</h3>
-                <div id="carouselExampleIndicators" class="carousel slide" data-ride="carousel">
+                <div id="carouselExampleIndicators" class="carousel slide carousel_max" data-ride="carousel">
                     <ol class="carousel-indicators">
                         <li data-target="#carouselExampleIndicators" data-slide-to="0" class="active"></li>
                         <li data-target="#carouselExampleIndicators" data-slide-to="1"></li>
                         <li data-target="#carouselExampleIndicators" data-slide-to="2"></li>
                     </ol>
-                    <div class="carousel-inner">
-                        <div class="carousel-item active">
-                            <img class="d-block w-100" src="img/img1.jpg" alt="First slide">
+                    <div class="carousel-inner w-100 h-100">
+                        <div class="carousel-item active w-100 h-100">
+                            <img class="d-block w-100 h-100" src="img/img1.jpg" alt="First slide">
                             <div class="carousel-caption d-none d-md-block">
                                 <h5>Pictures</h5>
                                 <p>A carousel of picture</p>
                             </div>
                         </div>
-                        <div class="carousel-item">
-                            <img class="d-block w-100" src="img/img2.jpg" alt="Second slide">
+                        <div class="carousel-item w-100 h-100">
+                            <img class="d-block w-100 h-100" src="img/img2.jpg" alt="Second slide">
                         </div>
-                        <div class="carousel-item">
-                            <img class="d-block w-100" src="img/img3.jpg" alt="Third slide">
+                        <div class="carousel-item w-100 h-100">
+                            <img class="d-block w-100 h-100" src="img/img3.jpg" alt="Third slide">
                         </div>
                     </div>
                     <a class="carousel-control-prev" href="#carouselExampleIndicators" role="button" data-slide="prev">

--- a/style.css
+++ b/style.css
@@ -24,3 +24,18 @@ footer {
 
 #slides {margin-bottom:10px;}
 #tourDates {margin-top: 10px;}
+
+.carousel_max {
+    max-width: 50vw;
+    max-height: 50vh;
+    overflow: hidden;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.carousel_max img {
+    object-fit: contain;
+    object-position: 50% 50%;
+    margin-left: auto;
+    margin-right: auto;
+}


### PR DESCRIPTION
Third image is now re-sized - cropped to same size as the other 2.
For future reference I think it would be easier to edit images to be all same size before using them for website.